### PR TITLE
Features/add owner repo input

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ If it is needed to specify which owner and repository the branches are located i
     branches: test
     suffix: -done
  - name: Delete branch in specific repository with a specific owner
-  uses: dawidd6/action-delete-branch@v3
-  with:
+   uses: dawidd6/action-delete-branch@v3
+   with:
     github_token: ${{github.token}}
     owner: specific-owner
     repository: specific-repository

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 An action that deletes multiple branches from repository.
 Optionally one can provide a `prefix` or `suffix` strings that would be appended or prepended to every branch name.
+If it is needed to specify which owner and repository the branches are located in, then the `owner` and `repository` can be provided as well.
 
 ## Usage
 
@@ -23,6 +24,14 @@ Optionally one can provide a `prefix` or `suffix` strings that would be appended
   uses: dawidd6/action-delete-branch@v3
   with:
     github_token: ${{github.token}}
+    branches: test
+    suffix: -done
+ - name: Delete branch in specific repository with a specific owner
+  uses: dawidd6/action-delete-branch@v3
+  with:
+    github_token: ${{github.token}}
+    owner: specific-owner
+    repository: specific-repository
     branches: test
     suffix: -done
 ```

--- a/action.yml
+++ b/action.yml
@@ -10,10 +10,10 @@ inputs:
     required: false
     default: ${{github.token}}
   owner:
-    description: Owner of the repository. Will be deducted from github_token if it is not provided
+    description: Owner of the repository. The owner will be deducted from env vars
     required: false
   repository:
-    description: The repository containing the branch(es) to be deleted. Will be deducted from github_token if it is not provided
+    description: The repository containing the branch(es) to be deleted. The repository name will be deducted from env vars
     required: false
   branches:
     description: Branches to delete (comma separated)

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,12 @@ inputs:
     description: GitHub token
     required: false
     default: ${{github.token}}
+  owner:
+    description: Owner of the repository. Will be deducted from github_token if it is not provided
+    required: false
+  repository:
+    description: The repository containing the branch(es) to be deleted. Will be deducted from github_token if it is not provided
+    required: false
   branches:
     description: Branches to delete (comma separated)
     required: false

--- a/main.js
+++ b/main.js
@@ -34,7 +34,7 @@ async function main() {
             if (suffix)
                 branch = branch + suffix
             
-            console.log("==> Deleting \"" + branch + "\" branch")
+            console.log("==> Deleting \"" + ownerOfRepository + "/" + repositoryContainingBranches + "/" + branch + "\" branch")
             
             await client.git.deleteRef({
                 owner: ownerOfRepository,

--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ async function main() {
         const branches = core.getInput("branches")
         const prefix = core.getInput("prefix")
         const suffix = core.getInput("suffix")
-        
+
         const client = github.getOctokit(token)
 
         let branchesToDelete = branches ? branches.split(",") : []

--- a/main.js
+++ b/main.js
@@ -5,10 +5,12 @@ async function main() {
     try {
         const token = core.getInput("github_token", { required: true })
         const numbers = core.getInput("numbers")
+        const owner = core.getInput("owner")
+        const repository = core.getInput("repository")
         const branches = core.getInput("branches")
         const prefix = core.getInput("prefix")
         const suffix = core.getInput("suffix")
-
+        
         const client = github.getOctokit(token)
 
         let branchesToDelete = branches ? branches.split(",") : []
@@ -23,14 +25,20 @@ async function main() {
             }
         }
 
+        let ownerOfRepository = owner ? owner : github.context.repo.owner
+        let repositoryContainingBranches = repository ? repository : github.context.repo.repo
+        
         for (let branch of branchesToDelete) {
             if (prefix)
                 branch = prefix + branch
             if (suffix)
                 branch = branch + suffix
+            
             console.log("==> Deleting \"" + branch + "\" branch")
+            
             await client.git.deleteRef({
-                ...github.context.repo,
+                owner: ownerOfRepository,
+                repo: repositoryContainingBranches,
                 ref: "heads/" + branch
             })
         }


### PR DESCRIPTION
This implementation gives the user the possibility to specify the owner and repository where the branches that should be deleted are located. This is done in order to not **only** be able to delete branches in the repository that the action is called from or the GitHub token dictates.