### PR TITLE
Features/missing ref warning instead of error

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An action that deletes multiple branches from repository.
 Optionally one can provide a `prefix` or `suffix` strings that would be appended or prepended to every branch name.
 If it is needed to specify which owner and repository the branches are located in, then the `owner` and `repository` can be provided as well.
-If setting the `soft_fail` flag to `true` a warning will be written to the console, and the action will continue, instead of the the action failing. The default is `false`.
+If setting the `soft_fail` flag to `true` a warning will be written to the console, and the action will continue, instead of the action failing. The default is `false`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An action that deletes multiple branches from repository.
 Optionally one can provide a `prefix` or `suffix` strings that would be appended or prepended to every branch name.
 If it is needed to specify which owner and repository the branches are located in, then the `owner` and `repository` can be provided as well.
-If a branch is not found, a warning will be written to the console, and the action will continue.
+If setting the `soft_fail` flag to `true` a warning will be written to the console, and the action will continue, instead of the the action failing. The default is `false`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 An action that deletes multiple branches from repository.
 Optionally one can provide a `prefix` or `suffix` strings that would be appended or prepended to every branch name.
 If it is needed to specify which owner and repository the branches are located in, then the `owner` and `repository` can be provided as well.
+If a branch is not found, a warning will be written to the console, and the action will continue.
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
   suffix:
     description: Additional suffix to append to every branch name
     required: false
+  soft_fail:
+    description: If set to `true` the workflow will continue if a branch reference is not found
+    required: false
+    default: false
 runs:
   using: node12
   main: main.js

--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ async function main() {
         const branches = core.getInput("branches")
         const prefix = core.getInput("prefix")
         const suffix = core.getInput("suffix")
-        const shouldFailSoftly = core.getInput("soft_fail")
+        const soft_fail = core.getInput("soft_fail")
         
         const client = github.getOctokit(token)
 
@@ -44,7 +44,9 @@ async function main() {
                     ref: "heads/" + branch
                 })
             } catch (error) {
-                if(shouldFailSoftly)
+                const shouldFailSoftly = (soft_fail === 'true');
+                
+                if(shouldFailSoftly === )
                     core.warning(error.message)
                 else
                     core.setFailed(error.message)

--- a/main.js
+++ b/main.js
@@ -36,11 +36,15 @@ async function main() {
             
             console.log("==> Deleting \"" + ownerOfRepository + "/" + repositoryContainingBranches + "/" + branch + "\" branch")
             
-            await client.git.deleteRef({
-                owner: ownerOfRepository,
-                repo: repositoryContainingBranches,
-                ref: "heads/" + branch
-            })
+            try {
+                await client.git.deleteRef({
+                    owner: ownerOfRepository,
+                    repo: repositoryContainingBranches,
+                    ref: "heads/" + branch
+                })
+            } catch (error) {
+                core.warning(error.message)
+            }
         }
     } catch (error) {
         core.setFailed(error.message)

--- a/main.js
+++ b/main.js
@@ -10,6 +10,7 @@ async function main() {
         const branches = core.getInput("branches")
         const prefix = core.getInput("prefix")
         const suffix = core.getInput("suffix")
+        const shouldFailSoftly = core.getInput("soft_fail")
         
         const client = github.getOctokit(token)
 
@@ -43,7 +44,10 @@ async function main() {
                     ref: "heads/" + branch
                 })
             } catch (error) {
-                core.warning(error.message)
+                if(shouldFailSoftly)
+                    core.warning(error.message)
+                else
+                    core.setFailed(error.message)
             }
         }
     } catch (error) {

--- a/main.js
+++ b/main.js
@@ -46,7 +46,7 @@ async function main() {
             } catch (error) {
                 const shouldFailSoftly = (soft_fail === 'true');
                 
-                if(shouldFailSoftly === )
+                if(shouldFailSoftly)
                     core.warning(error.message)
                 else
                     core.setFailed(error.message)


### PR DESCRIPTION
This implementation gives the user the possibility to decide if the action should fail with an error or continue with a warning. This is done in order to make the action more flexible in the cases where a branch does not exist but the rest of the workflow that the action is used in is not dependent on that condition.